### PR TITLE
chore: Add instructions to self-deploy, in case of snoopage :P

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,41 @@ switch (result.status) {
 
 Not actively. Cloudflare lets me start streaming live access logs down on-demand, and these logs tell me the IP address and inferred location of the request, which is far from ideal. You'll just have to trust that I'm not storing that anywhere.
 
-If you're concerned I may be snooping, feel free to run your own instance!
+If you're concerned I may be snooping, feel free to run your own instance:
+
+### Prerequisites
+
+This project requires [NodeJS](https://nodejs.org/) (version 16.10 or later) and [NPM](https://npmjs.org/). To make sure you have them available on your machine,
+try running the following command:
+
+```sh
+$ npm -v && node -v
+7.20.3
+v16.15.1
+```
+
+### Clone the repo
+
+```sh
+$ cd path/to/parent
+$ git clone https://github.com/AverageHelper/ip-echo-cloudflare.git
+$ cd ip-echo-cloudflare
+```
+
+### Install dependencies
+
+```sh
+$ npm ci
+```
+
+### Make sure everything lints and compiles
+
+```sh
+$ npm run build
+```
+
+### Deploy to your own Cloudflare zone
+
+```sh
+$ npm run deploy
+```


### PR DESCRIPTION
I cannot prove I'm not logging, and people are bound to not want to take my word that I'm not watching Cloudflare's logs or piping them anywhere.

Folks can freely run their own instance of this, with a nice 100,000 request-per-day limit (at time of writing). This PR adds easy instructions to the README.