### PR TITLE
fix: Disallow data providers from responding with anything but a primitive value

### DIFF
--- a/src/fetchHandler.ts
+++ b/src/fetchHandler.ts
@@ -60,7 +60,7 @@ export function headHandlerFor(provider: DataProvider): Handler {
  * @returns An appropriate `Response` object.
  */
 async function fetchHandler(c: Context, provider: DataProvider): Promise<Response> {
-	const data = await provider(c);
+	const data: Data = await provider(c);
 	const accept = c.req.headers.get("accept");
 	let message: string;
 	let contentType: string;

--- a/src/fetchHandler.ts
+++ b/src/fetchHandler.ts
@@ -2,10 +2,14 @@ import type { Context } from "hono";
 import type { Next } from "hono/dist/types/types";
 import { headers } from "./headers";
 
+type Primitive = string | number | boolean;
+
+type Data = Primitive | Array<Primitive> | Record<string, Primitive>;
+
 /**
  * A function that handles a request and provides some data in response.
  */
-type DataProvider = (c: Context) => unknown | Promise<unknown>;
+type DataProvider = (c: Context) => Data | Promise<Data>;
 
 /**
  * A Hono request handler function.

--- a/src/routes/about.ts
+++ b/src/routes/about.ts
@@ -3,6 +3,6 @@ import { repo, title, version } from "../meta";
 /**
  * @returns Some metadata about the project.
  */
-export function about(): object {
+export function about(): Record<string, string> {
 	return { repo, title, version };
 }


### PR DESCRIPTION
In the interest of preventing basic handlers and data providers from forwarding objects that they should not (like sending a `Response` object as part of [some tutorial](https://developers.cloudflare.com/workers/learning/using-websockets/) or smth), I've modified the `DataProvider` type to be more specific about what is permitted.

This makes things safer too. Now, the data formatter expressly expects a "`Data`" value, and won't accidentally forget to `await` a Promise.